### PR TITLE
Issues/#4

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,7 +30,7 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assigned_user == current_user
+    elsif assigned_user == current_user || current_user == assign.team.owner
       assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,7 +30,8 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assign.destroy
+    elsif assigned_user == current_user
+      assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')
     else

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,12 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    if current_user == @team.owner
+    else
+      redirect_to @team, notice: I18n.t('views.messages.cannot_edit_team')
+    end
+  end
 
   def create
     @team = Team.new(team_params)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -244,6 +244,7 @@ ja:
       team_members: 'チームメンバーの一覧'
       team_members2: 'チームメンバー'
       edit_team: 'チームを編集する'
+      cannot_edit_team: 'チームを編集できるのはチームリーダーだけです'
       invite_team_member: 'チームメンバー招待'
       team_leader: 'チームリーダー'
       leader: 'リーダー'


### PR DESCRIPTION
# チーム情報の操作に関しての機能を整えること

現状では、

そのTeamに所属しているUserの削除（離脱）が、どのUserでもできる
TeamのeditをTeamのリーダー（オーナー）以外でも自由にできる
という仕様になっているが、これを、

Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
TeamのeditはTeamのリーダー（オーナー）のみができるようにすること
という仕様に変更すること

また、その他、アプリケーションの挙動に不審な点やエラーがないこと。

その他、質問や確認事項などがあれば別途課題投稿欄のコメントで質問すること

今回テストは不要

